### PR TITLE
Implement edit event

### DIFF
--- a/app/(tabs)/(index,host)/event/[id]/edit.tsx
+++ b/app/(tabs)/(index,host)/event/[id]/edit.tsx
@@ -1,0 +1,182 @@
+import { useRouter, useLocalSearchParams } from "expo-router";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
+import { YStack, SizableText, XStack } from "tamagui";
+
+import { Button } from "@/components/Button";
+import { CustomContainer } from "@/components/CustomContainer";
+import { FloatingActionButton } from "@/components/FloatingActionButton";
+import { FormField } from "@/components/FormField";
+import { TextArea } from "@/components/Input";
+import { IconSymbol } from "@/components/ui/IconSymbol";
+import { useEventById } from "@/hooks/use-event";
+import { useEventUpdate } from "@/hooks/use-event-update";
+import { useUser } from "@/hooks/use-user";
+
+export default function EditEvent() {
+  const params = useLocalSearchParams();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const { data: event } = useEventById(Number(id));
+  const { data: user, isLoading } = useUser();
+  const updateEvent = useEventUpdate();
+  const router = useRouter();
+
+  const form = useForm({
+    defaultValues: {
+      title: "",
+      address: "",
+      description: "",
+      eventDate: new Date(),
+    },
+  });
+
+  useEffect(() => {
+    if (event) {
+      form.reset({
+        title: event.title,
+        address: event.address,
+        description: event.description ?? "",
+        eventDate: new Date(event.eventDate),
+      });
+    }
+  }, [event, form]);
+
+  const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
+  const [isTimePickerVisible, setTimePickerVisibility] = useState(false);
+
+  const showDatePicker = () => {
+    setDatePickerVisibility(true);
+  };
+
+  const hideDatePicker = () => {
+    setDatePickerVisibility(false);
+  };
+
+  const showTimePicker = () => {
+    setTimePickerVisibility(true);
+  };
+
+  const hideTimePicker = () => {
+    setTimePickerVisibility(false);
+  };
+
+  const onSubmit = form.handleSubmit(async ({ eventDate, ...data }) => {
+    if (!user) {
+      alert("You must be logged in to edit an event.");
+      return;
+    }
+    try {
+      await updateEvent.mutateAsync({
+        id: Number(id),
+        eventDate: eventDate.toUTCString(),
+        ...data,
+      });
+      router.replace({
+        pathname: `/event/[id]`,
+        params: { id },
+      });
+    } catch (error) {
+      alert(
+        error instanceof Error
+          ? error.message
+          : "You are not allowed to perform this action.",
+      );
+    }
+  });
+
+  if (isLoading) {
+    return <SizableText>Loading...</SizableText>;
+  }
+
+  return (
+    <CustomContainer
+      scroll
+      cta={
+        <FloatingActionButton
+          iconAfter={<IconSymbol name="arrow.right" color="$color12" />}
+          onPress={onSubmit}
+          testID="submit-button"
+        >
+          Save changes
+        </FloatingActionButton>
+      }
+    >
+      <YStack padding="$4" paddingTop="$0" gap="$2">
+        <FormField
+          form={form}
+          name="title"
+          label="Event title"
+          inputProps={{
+            placeholder: "eg. Bingo night",
+            testID: "title-input",
+          }}
+        />
+        <FormField
+          form={form}
+          name="address"
+          label="Event address"
+          inputProps={{
+            placeholder: "eg. Kungsportsplatsen 1",
+            testID: "address-input",
+          }}
+        />
+        <FormField
+          form={form}
+          name="eventDate"
+          label="Date & Time"
+          render={({ field, inputProps }) => {
+            const handleConfirm = (date: Date) => {
+              hideDatePicker();
+              hideTimePicker();
+              field.onChange(date);
+            };
+            return (
+              <XStack gap="$4" width="100%">
+                <Button
+                  {...inputProps}
+                  onPress={showDatePicker}
+                  flex={1}
+                  variant="input"
+                >
+                  {field.value.toDateString()}
+                </Button>
+                <DateTimePickerModal
+                  isVisible={isDatePickerVisible}
+                  mode="date"
+                  onConfirm={handleConfirm}
+                  onCancel={hideDatePicker}
+                  minimumDate={new Date()}
+                />
+                <Button {...inputProps} onPress={showTimePicker} minWidth="$11">
+                  {field.value.toTimeString().slice(0, 5)}
+                </Button>
+                <DateTimePickerModal
+                  isVisible={isTimePickerVisible}
+                  mode="time"
+                  onConfirm={handleConfirm}
+                  onCancel={hideTimePicker}
+                />
+              </XStack>
+            );
+          }}
+        />
+        <FormField
+          form={form}
+          name="description"
+          label="Description"
+          render={({ field, inputProps }) => (
+            <TextArea
+              placeholder="eg. Details about the event"
+              height={100}
+              {...inputProps}
+              onChangeText={field.onChange}
+              value={field.value}
+              testID="description-input"
+            />
+          )}
+        />
+      </YStack>
+    </CustomContainer>
+  );
+}

--- a/app/(tabs)/(index,host)/event/[id]/edit.tsx
+++ b/app/(tabs)/(index,host)/event/[id]/edit.tsx
@@ -2,6 +2,7 @@ import { useRouter, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
+import { showToastable } from "react-native-toastable";
 import { YStack, SizableText, XStack } from "tamagui";
 
 import { Button } from "@/components/Button";
@@ -17,7 +18,7 @@ import { useUser } from "@/hooks/use-user";
 export default function EditEvent() {
   const params = useLocalSearchParams();
   const id = Array.isArray(params.id) ? params.id[0] : params.id;
-  const { data: event } = useEventById(Number(id));
+  const { data: event } = useEventById(id);
   const { data: user, isLoading } = useUser();
   const updateEvent = useEventUpdate();
   const router = useRouter();
@@ -63,25 +64,33 @@ export default function EditEvent() {
 
   const onSubmit = form.handleSubmit(async ({ eventDate, ...data }) => {
     if (!user) {
-      alert("You must be logged in to edit an event.");
-      return;
+      showToastable({
+        message: "You must be logged in to create an event",
+        duration: 2000,
+        status: "success",
+      });
     }
     try {
       await updateEvent.mutateAsync({
-        id: Number(id),
+        id: id,
         eventDate: eventDate.toUTCString(),
         ...data,
+      });
+      showToastable({
+        message: "Event edited successfully",
+        duration: 2000,
+        status: "success",
       });
       router.replace({
         pathname: `/event/[id]`,
         params: { id },
       });
-    } catch (error) {
-      alert(
-        error instanceof Error
-          ? error.message
-          : "You are not allowed to perform this action.",
-      );
+    } catch {
+      showToastable({
+        message: "Error editing event",
+        duration: 2000,
+        status: "warning",
+      });
     }
   });
 

--- a/app/(tabs)/(index,host)/event/[id]/edit.tsx
+++ b/app/(tabs)/(index,host)/event/[id]/edit.tsx
@@ -18,7 +18,7 @@ import { useUser } from "@/hooks/use-user";
 export default function EditEvent() {
   const params = useLocalSearchParams();
   const id = Array.isArray(params.id) ? params.id[0] : params.id;
-  const { data: event } = useEventById(id);
+  const { data: event, isFetching } = useEventById(id);
   const { data: user, isLoading } = useUser();
   const updateEvent = useEventUpdate();
   const router = useRouter();
@@ -94,7 +94,7 @@ export default function EditEvent() {
     }
   });
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return <SizableText>Loading...</SizableText>;
   }
 

--- a/app/(tabs)/(index,host)/event/[id]/index.tsx
+++ b/app/(tabs)/(index,host)/event/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { Link, Stack, useLocalSearchParams } from "expo-router";
+import { Link, Stack, useLocalSearchParams, router } from "expo-router";
 import React, { ReactNode } from "react";
 import { SizableText, Text, View, XStack, YStack } from "tamagui";
 
@@ -81,6 +81,12 @@ export default function EventPage() {
   const cta = userOwnsEvent ? (
     <FloatingActionButton
       iconAfter={<IconSymbol name="square.and.pencil" color="$color12" />}
+      onPress={() => {
+        router.push({
+          pathname: `/event/[id]/edit`,
+          params: { id: event.id },
+        });
+      }}
       testID="edit-button"
     >
       Edit Event

--- a/hooks/use-event-update.ts
+++ b/hooks/use-event-update.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { usePayload } from "./use-payload";
+
+export function useEventUpdate() {
+  const payload = usePayload();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (formData: {
+      id: number;
+      title: string;
+      address: string;
+      description?: string;
+      eventDate: string;
+    }) => {
+      return payload.collections.event.updateById({
+        id: formData.id.toString(),
+        patch: {
+          title: formData.title,
+          address: formData.address,
+          description: formData.description,
+          eventDate: formData.eventDate,
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}

--- a/hooks/use-event-update.ts
+++ b/hooks/use-event-update.ts
@@ -8,7 +8,7 @@ export function useEventUpdate() {
 
   return useMutation({
     mutationFn: async (formData: {
-      id: number;
+      id: string;
       title: string;
       address: string;
       description?: string;

--- a/hooks/use-event.ts
+++ b/hooks/use-event.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { usePayload } from "./use-payload";
 
-export function useEventById(eventId: number) {
+export function useEventById(eventId: string) {
   const payload = usePayload();
 
   return useQuery({


### PR DESCRIPTION
This pull request introduces a new feature to allow organizers to edit events. The changes include creating an event editing page, updating the event details, and adding navigation to the edit page.

New feature implementation:

* `app/(tabs)/(index,host)/event/[id]/edit.tsx`: Created a new component for editing events.
* [`hooks/use-event-update.ts`](diffhunk://#diff-cee814027854e4607b8d14825222ea95faf684a2411afe97a966cf7318ec529eR1-R31): Added a new hook `useEventUpdate` to handle updating event details using a mutation with `react-query`.

Navigation updates:

* `app/(tabs)/(index,host)/event/[id]/index.tsx`: Added navigation to the event edit page when the user owns the event.

Closes #36 